### PR TITLE
Fix for https://bugs.eclipse.org/bugs/show_bug.cgi?id=487483

### DIFF
--- a/bundles/org.eclipse.vorto.codegen.ui/src/org/eclipse/vorto/codegen/ui/handler/ConfigurationElementLookup.java
+++ b/bundles/org.eclipse.vorto.codegen.ui/src/org/eclipse/vorto/codegen/ui/handler/ConfigurationElementLookup.java
@@ -46,6 +46,16 @@ public class ConfigurationElementLookup {
 				id);
 		return extension.getConfigurationElements();
 	}
+	
+	public String getExtensionSimpleIdentifier(String extensionPtId, String id) {
+		IExtension extension = EXTENSION_REGISTRY.getExtension(extensionPtId,
+				id);
+		if (extension != null) {
+			return extension.getSimpleIdentifier();
+		}
+		
+		return null;
+	}
 
 	public void setExtensionRegistry(IExtensionRegistry reg) {
 		this.EXTENSION_REGISTRY = reg;

--- a/bundles/org.eclipse.vorto.codegen/src/org/eclipse/vorto/codegen/api/DefaultMappingContext.java
+++ b/bundles/org.eclipse.vorto.codegen/src/org/eclipse/vorto/codegen/api/DefaultMappingContext.java
@@ -51,8 +51,6 @@ public class DefaultMappingContext implements IMappingContext {
 		this.allMappingModels.add(mappingModel);
 	}
 
-	
-
 	@Override
 	public List<MappingRule> getMappingRulesByOperation(Operation operation) {
 		List<MappingRule> mappingRules = new ArrayList<>();

--- a/bundles/org.eclipse.vorto.core.ui/src/org/eclipse/vorto/core/model/AbstractModelProject.java
+++ b/bundles/org.eclipse.vorto.core.ui/src/org/eclipse/vorto/core/model/AbstractModelProject.java
@@ -17,6 +17,8 @@ package org.eclipse.vorto.core.model;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -34,6 +36,7 @@ import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.vorto.core.api.model.datatype.Type;
 import org.eclipse.vorto.core.api.model.functionblock.FunctionblockModel;
 import org.eclipse.vorto.core.api.model.informationmodel.InformationModel;
+import org.eclipse.vorto.core.api.model.mapping.MappingModel;
 import org.eclipse.vorto.core.api.model.model.Model;
 import org.eclipse.vorto.core.api.model.model.ModelId;
 import org.eclipse.vorto.core.api.model.model.ModelReference;
@@ -138,8 +141,12 @@ public abstract class AbstractModelProject extends AbstractModelElement implemen
 	}
 
 	@Override
-	public IMapping getMapping(String targetPlatform){
-		return MappingResourceFactory.getInstance().createMapping(this, targetPlatform);		
+	public Collection<MappingModel> getMapping(String targetPlatform){
+		if (targetPlatform == null) {
+			return Collections.emptyList();
+		}
+		
+		return MappingResourceFactory.getInstance().getMappingModels(this, targetPlatform);		
 	}
 	
 	protected IModelElementResolver[] getResolvers() {

--- a/bundles/org.eclipse.vorto.core.ui/src/org/eclipse/vorto/core/model/IModelProject.java
+++ b/bundles/org.eclipse.vorto.core.ui/src/org/eclipse/vorto/core/model/IModelProject.java
@@ -14,9 +14,12 @@
  *******************************************************************************/
 package org.eclipse.vorto.core.model;
 
+import java.util.Collection;
+
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.vorto.core.api.model.mapping.MappingModel;
 import org.eclipse.vorto.core.api.model.model.ModelId;
 
 /**
@@ -60,7 +63,7 @@ public interface IModelProject extends IModelElement {
 	 * @param targetPlatform: Target platform name the mapping designed for
 	 * @return instance if IMapping
 	 */
-	IMapping getMapping(String targetPlatform);
+	Collection<MappingModel> getMapping(String targetPlatform);
 
 	/**
 	 * Saves the actual model project, after it has been modified, e.g. after

--- a/bundles/org.eclipse.vorto.core.ui/src/org/eclipse/vorto/core/model/MappingResourceFactory.java
+++ b/bundles/org.eclipse.vorto.core.ui/src/org/eclipse/vorto/core/model/MappingResourceFactory.java
@@ -81,6 +81,13 @@ public class MappingResourceFactory {
 		List<IMapping> referenceMappings = this.getReferenceMappings(ownerModelElement, targetPlatform);
 		return createMapping(mappingModel, referenceMappings);
 	}
+	
+	public List<MappingModel> getMappingModels(IModelElement ownerModelElement, String targetPlatform) {
+		List<MappingModel> mappingModels = new ArrayList<MappingModel>();
+		mappingModels.add(getMappingModel(ownerModelElement, targetPlatform));
+		mappingModels.addAll(getReferenceMappingModels(ownerModelElement, targetPlatform));
+		return mappingModels;
+	}
 
 	/**
 	 * Create IMapping instance based on given Mapping Model and child IMapping 
@@ -148,6 +155,14 @@ public class MappingResourceFactory {
 		return mappingModel;
 	}
 
+	private List<MappingModel> getReferenceMappingModels(IModelElement ownerModelElement, String targetPlatform) {
+		List<MappingModel> referenceMappings = new ArrayList<MappingModel>();
+		for (IModelElement referenceModelElement : ownerModelElement.getReferences()) {
+			referenceMappings.add(getMappingModel(referenceModelElement, targetPlatform));
+		}
+		return referenceMappings;
+	}
+	
 	private List<IMapping> getReferenceMappings(IModelElement ownerModelElement, String targetPlatform) {
 		List<IMapping> referenceMappings = new ArrayList<IMapping>();
 		for (IModelElement referenceModelElement : ownerModelElement.getReferences()) {


### PR DESCRIPTION
Passed local mapping context to generators when generating from the toolset. Also fixes https://bugs.eclipse.org/bugs/show_bug.cgi?id=487483 - Mapping-rules of events are ignored when generating code

Signed-off-by: Erle Czar Mantos <erleczar.mantos@bosch-si.com>